### PR TITLE
When not defining the --enable-test to autogen.sh, the configure fails.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,13 +56,11 @@ if test "x$TEST" = xyes; then
     # Check for individual driver implementations... not required for
     # libdri2, but is required for the test app to map the buffer..
     PKG_CHECK_MODULES(NOUVEAU, libdrm_nouveau, [HAVE_NOUVEAU=yes], [HAVE_NOUVEAU=no])
-    AM_CONDITIONAL(ENABLE_NOUVEAU, [test "x$HAVE_NOUVEAU" = xyes])
     if test "x$HAVE_NOUVEAU" = "xyes"; then
         have_drm_driver=yes
         AC_DEFINE(HAVE_NOUVEAU, 1, [Have nouveau support])
     fi
     PKG_CHECK_MODULES(OMAP, libdrm_omap, [HAVE_OMAP=yes], [HAVE_OMAP=no])
-    AM_CONDITIONAL(ENABLE_OMAP, [test "x$HAVE_OMAP" = xyes])
     if test "x$HAVE_OMAP" = "xyes"; then
         have_drm_driver=yes
         AC_DEFINE(HAVE_OMAP, 1, [Have omap support])
@@ -75,6 +73,8 @@ if test "x$TEST" = xyes; then
         TEST=no
     fi
 fi
+AM_CONDITIONAL(ENABLE_OMAP, [test "x$HAVE_OMAP" = xyes])
+AM_CONDITIONAL(ENABLE_NOUVEAU, [test "x$HAVE_NOUVEAU" = xyes])
 AM_CONDITIONAL(ENABLE_TEST, [test "x$TEST" = xyes])
 
 # Allow checking code with lint, sparse, etc.

--- a/src/dri2.c
+++ b/src/dri2.c
@@ -43,8 +43,6 @@
 #include <X11/extensions/dri2proto.h>
 #include <drm.h>
 #include <xf86drm.h>
-#include <GL/glx.h>
-#include <GL/glxext.h>
 #include <xorg/list.h>
 #include "X11/extensions/dri2.h"
 


### PR DESCRIPTION
  Usage of Conditionals describes that a conditional
  must be defined before it is used in configure.ac
  using the macro AM_CONDITIONAL.
  This commit fixes ./configure step when --enable-test is
  undefined.
